### PR TITLE
cc: Fix missing std and C++ exception enabling flags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,13 @@ fn main() {
         .file(src_path.join("wrapper.cpp"))
         .include(Path::new("signalsmith-stretch"))
         .include(Path::new("."))
+        // wrapper.cpp uses auto -- set a C++ standard usable by
+        // MSVC for consistency
+        .flag_if_supported("-std=c++14")
+        .flag_if_supported("/std:c++14")
+        // wrapper.cpp also uses throwables
+        .flag_if_supported("-fexceptions")
+        .flag_if_supported("/EHs")
         .cpp(true)
         .compile("signalsmith-stretch");
 


### PR DESCRIPTION
Hi,

Coming here from the GStreamer folks to file this MR fixing `signalsmith-stretch` build on macOS, iOS and Android.

Xcode pre 26's default C++ standard is C++0x, and the Android NDK can be also set to disable exceptions by default, [which is the case of the GStreamer SDK](https://gitlab.freedesktop.org/gstreamer/cerbero/-/commit/973905f6c0fcbb44da00de17524e51388907c14e). This causes the following build failures:

- https://gitlab.freedesktop.org/gstreamer/cerbero/-/jobs/84619199#L499
- https://gitlab.freedesktop.org/gstreamer/cerbero/-/jobs/84619203#L477
- https://gitlab.freedesktop.org/gstreamer/cerbero/-/jobs/84619202#L461

The wrapper uses `auto` and throw, so this PR sets a suitable C++ standard (C++14 is the default on Xcode 26 and the Android NDK) and explicitly enables exceptions.

Let me know what you think.

cc @sdroege