### PR TITLE
Explicitly set visibility of exported symbols to "default"

### DIFF
--- a/src/wrapper.h
+++ b/src/wrapper.h
@@ -4,6 +4,8 @@
 #include <stddef.h>
 #include <stdbool.h>
 
+#define EXPORT __attribute__((visibility("default")))
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -12,61 +14,61 @@ struct signalsmith_stretch;
 typedef struct signalsmith_stretch signalsmith_stretch_t;
 
 // Creates a new SignalsmithStretch instance.
-signalsmith_stretch_t *signalsmith_stretch_create(int channel_count, size_t block_length, size_t interval);
-signalsmith_stretch_t *signalsmith_stretch_create_preset_default(int channel_count, float sample_rate);
-signalsmith_stretch_t *signalsmith_stretch_create_preset_cheaper(int channel_count, float sample_rate);
+EXPORT signalsmith_stretch_t *signalsmith_stretch_create(int channel_count, size_t block_length, size_t interval);
+EXPORT signalsmith_stretch_t *signalsmith_stretch_create_preset_default(int channel_count, float sample_rate);
+EXPORT signalsmith_stretch_t *signalsmith_stretch_create_preset_cheaper(int channel_count, float sample_rate);
 
 // Destroys a SignalsmithStretch instance.
-void signalsmith_stretch_destroy(signalsmith_stretch_t *handle);
+EXPORT void signalsmith_stretch_destroy(signalsmith_stretch_t *handle);
 
 // Resets the instance.
-void signalsmith_stretch_reset(signalsmith_stretch_t *handle);
+EXPORT void signalsmith_stretch_reset(signalsmith_stretch_t *handle);
 
 // Gets the current input latency in frames.
-size_t signalsmith_stretch_input_latency(signalsmith_stretch_t *handle);
+EXPORT size_t signalsmith_stretch_input_latency(signalsmith_stretch_t *handle);
 
 // Gets the current output latency in frames.
-size_t signalsmith_stretch_output_latency(signalsmith_stretch_t *handle);
+EXPORT size_t signalsmith_stretch_output_latency(signalsmith_stretch_t *handle);
 
 // Provides input, or "pre-roll", without affecting the stream position.
-void signalsmith_stretch_seek(signalsmith_stretch_t *handle, float *input, size_t input_length, double playback_rate);
+EXPORT void signalsmith_stretch_seek(signalsmith_stretch_t *handle, float *input, size_t input_length, double playback_rate);
 
 // Set the frequency multiplier and an optional tonality limit (pass zero for
 // no limit).
-void signalsmith_stretch_set_transpose_factor(signalsmith_stretch_t *handle, float multiplier, float tonality_limit);
+EXPORT void signalsmith_stretch_set_transpose_factor(signalsmith_stretch_t *handle, float multiplier, float tonality_limit);
 
 // Set the frequency multiplier in semitones, as well as an optional tonality
 // limit (pass zero for no limit).
-void signalsmith_stretch_set_transpose_factor_semitones(signalsmith_stretch_t *handle, float multiplier, float tonality_limit);
+EXPORT void signalsmith_stretch_set_transpose_factor_semitones(signalsmith_stretch_t *handle, float multiplier, float tonality_limit);
 
 // Set formant shift factor, with an option to compensate for pitch.
-void signalsmith_stretch_set_formant_factor(signalsmith_stretch_t *handle, float multiplier, int compensate_pitch);
+EXPORT void signalsmith_stretch_set_formant_factor(signalsmith_stretch_t *handle, float multiplier, int compensate_pitch);
 
 // Set formant shift in semitones, with an option to compensate for pitch.
-void signalsmith_stretch_set_formant_factor_semitones(signalsmith_stretch_t *handle, float semitones, int compensate_pitch);
+EXPORT void signalsmith_stretch_set_formant_factor_semitones(signalsmith_stretch_t *handle, float semitones, int compensate_pitch);
 
-// Rough guesstimate of the fundamental frequency, used for formant analysis. 
+// Rough guesstimate of the fundamental frequency, used for formant analysis.
 // 0 means attempting to detect the pitch.
-void signalsmith_stretch_set_formant_base(signalsmith_stretch_t *handle, float frequency);
+EXPORT void signalsmith_stretch_set_formant_base(signalsmith_stretch_t *handle, float frequency);
 
 // Processes interleaved input samples and stores the result in the output buffer.
 // The input and output buffers must interleaved, with the correct number of
 // channels. The length arguments refer to the number of frames, i.e. the number
 // of samples per channel.
-void signalsmith_stretch_process(signalsmith_stretch_t *handle,
-                                 float *input, size_t input_length,
-                                 float *output, size_t output_length);
+EXPORT void signalsmith_stretch_process(signalsmith_stretch_t *handle,
+                                        float *input, size_t input_length,
+                                        float *output, size_t output_length);
 
 
 // Process a complete audio buffer all in one go.
-bool signalsmith_stretch_exact(signalsmith_stretch_t *handle,
-                               float *input, size_t input_length,
-                               float *output, size_t output_length);
+EXPORT bool signalsmith_stretch_exact(signalsmith_stretch_t *handle,
+                                      float *input, size_t input_length,
+                                      float *output, size_t output_length);
 
 // Read the remaining output. `signalsmith_stretch_output_latency` will return
 // the correct size for the output buffer.
-void signalsmith_stretch_flush(signalsmith_stretch_t *handle,
-                               float *output, size_t output_length);
+EXPORT void signalsmith_stretch_flush(signalsmith_stretch_t *handle,
+                                      float *output, size_t output_length);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Explicitly set the visibility of exported `signalsmith_*` symbols to `"default"` to ensure they are discoverable by bindgen when building for WASM targets.

This addresses the issue described in https://github.com/rust-lang/rust-bindgen/issues/2989.